### PR TITLE
Revamp style with product catalog

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kentack - Contact</title>
   <link rel="stylesheet" href="style.css">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <nav class="animate">

--- a/images/driver.svg
+++ b/images/driver.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect width="400" height="300" fill="#e0e0e0"/>
+  <text x="200" y="150" font-size="24" text-anchor="middle" fill="#333">Driver</text>
+</svg>

--- a/images/hero.svg
+++ b/images/hero.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect width="400" height="300" fill="#e0e0e0"/>
+  <text x="200" y="150" font-size="24" text-anchor="middle" fill="#333">Irons Set</text>
+</svg>

--- a/images/irons.svg
+++ b/images/irons.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect width="400" height="300" fill="#e0e0e0"/>
+  <text x="200" y="150" font-size="24" text-anchor="middle" fill="#333">Irons Set</text>
+</svg>

--- a/images/putter.svg
+++ b/images/putter.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">
+  <rect width="400" height="300" fill="#e0e0e0"/>
+  <text x="200" y="150" font-size="24" text-anchor="middle" fill="#333">Putter</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kentack</title>
   <link rel="stylesheet" href="style.css">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <nav class="animate">
@@ -27,6 +27,7 @@
   </nav>
 
   <header class="hero">
+    <img src="images/hero.svg" alt="Kentack Collection" class="hero-image animate">
     <h1 class="animate" data-i18n="home_title">Luxury Golf Experience</h1>
     <p class="animate" data-i18n="home_desc">Discover high-end golf gear for champions.</p>
     <a href="products.html" class="btn-primary animate" data-i18n="hero_cta">Shop Now</a>

--- a/products.html
+++ b/products.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kentack - Products</title>
   <link rel="stylesheet" href="style.css">
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <nav class="animate">
@@ -29,12 +29,19 @@
   <main>
     <h1 class="animate" data-i18n="products_title">Our Products</h1>
     <div class="product animate">
-      <h2 data-i18n="product1_name">Elite Golf Clubs</h2>
-      <p data-i18n="product1_desc">Precision-crafted clubs for superior performance.</p>
+      <img src="images/irons.svg" alt="Golden Irons" class="product-image">
+      <h2 data-i18n="product1_name">Golden Irons Set</h2>
+      <p data-i18n="product1_desc">Complete set of handcrafted gold-plated irons.</p>
     </div>
     <div class="product animate">
-      <h2 data-i18n="product2_name">Premium Golf Balls</h2>
-      <p data-i18n="product2_desc">Engineered for distance and control.</p>
+      <img src="images/driver.svg" alt="Golden Driver" class="product-image">
+      <h2 data-i18n="product2_name">Golden Driver</h2>
+      <p data-i18n="product2_desc">Precision driver with gold finish.</p>
+    </div>
+    <div class="product animate">
+      <img src="images/putter.svg" alt="DragonEyes Putter" class="product-image">
+      <h2 data-i18n="product3_name">DragonEyes Putter</h2>
+      <p data-i18n="product3_desc">Artisan putter with detailed engraving.</p>
     </div>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -9,10 +9,12 @@ const translations = {
     home_desc: 'Discover high-end golf gear for champions.',
     hero_cta: 'Shop Now',
     products_title: 'Our Products',
-    product1_name: 'Elite Golf Clubs',
-    product1_desc: 'Precision-crafted clubs for superior performance.',
-    product2_name: 'Premium Golf Balls',
-    product2_desc: 'Engineered for distance and control.',
+    product1_name: 'Golden Irons Set',
+    product1_desc: 'Complete set of handcrafted gold-plated irons.',
+    product2_name: 'Golden Driver',
+    product2_desc: 'Precision driver with gold finish.',
+    product3_name: 'DragonEyes Putter',
+    product3_desc: 'Artisan putter with detailed engraving.',
     contact_title: 'Contact Us',
     contact_phone: 'Phone: 0899033692',
     contact_location_title: 'Location',
@@ -28,10 +30,12 @@ const translations = {
     home_desc: 'Khám phá thiết bị golf cao cấp dành cho nhà vô địch.',
     hero_cta: 'Mua Ngay',
     products_title: 'Sản phẩm của chúng tôi',
-    product1_name: 'Gậy Golf Đẳng Cấp',
-    product1_desc: 'Gậy được chế tác chính xác cho hiệu suất vượt trội.',
-    product2_name: 'Bóng Golf Cao Cấp',
-    product2_desc: 'Thiết kế cho khoảng cách và kiểm soát tối ưu.',
+    product1_name: 'Bộ Gậy Sắt Mạ Vàng',
+    product1_desc: 'Bộ gậy sắt mạ vàng chế tác thủ công hoàn hảo.',
+    product2_name: 'Gậy Driver Mạ Vàng',
+    product2_desc: 'Driver chính xác với lớp phủ vàng.',
+    product3_name: 'Gậy Putter DragonEyes',
+    product3_desc: 'Gậy putter thủ công với chạm khắc tinh xảo.',
     contact_title: 'Liên hệ với chúng tôi',
     contact_phone: 'Điện thoại: 0899033692',
     contact_location_title: 'Địa chỉ',
@@ -47,10 +51,12 @@ const translations = {
     home_desc: 'チャンピオンのための高級ゴルフ用品を見つけましょう。',
     hero_cta: '今すぐ購入',
     products_title: '製品一覧',
-    product1_name: 'エリートゴルフクラブ',
-    product1_desc: '卓越したパフォーマンスのために精密に作られたクラブ。',
-    product2_name: 'プレミアムゴルフボール',
-    product2_desc: '飛距離とコントロールのために設計。',
+    product1_name: 'ゴールドアイアンセット',
+    product1_desc: '手作りの金メッキアイアンセット。',
+    product2_name: 'ゴールドドライバー',
+    product2_desc: 'ゴールド仕上げの精密ドライバー。',
+    product3_name: 'ドラゴンアイズパター',
+    product3_desc: '精巧な彫刻入りのパター。',
     contact_title: 'お問い合わせ',
     contact_phone: '電話: 0899033692',
     contact_location_title: '住所',
@@ -81,14 +87,14 @@ function initLanguage() {
 
 function initTheme() {
   const saved = localStorage.getItem('theme');
-  if (saved === 'light') {
-    document.body.classList.add('light-theme');
+  if (saved === 'dark') {
+    document.body.classList.add('dark-theme');
   }
   const toggle = document.getElementById('theme-toggle');
   if (toggle) {
     toggle.addEventListener('click', () => {
-      document.body.classList.toggle('light-theme');
-      localStorage.setItem('theme', document.body.classList.contains('light-theme') ? 'light' : 'dark');
+      document.body.classList.toggle('dark-theme');
+      localStorage.setItem('theme', document.body.classList.contains('dark-theme') ? 'dark' : 'light');
     });
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,8 +1,9 @@
 :root {
-  --bg-color: #000000;
-  --text-color: #ffffff;
-  --accent-color: #ffd700;
+  --bg-color: #ffffff;
+  --text-color: #000000;
+  --accent-color: #000000;
   --font-family: 'Montserrat', sans-serif;
+  --heading-font: 'Playfair Display', serif;
 }
 
 html {
@@ -19,10 +20,10 @@ body {
   transition: background-color 0.5s, color 0.5s;
 }
 
-.light-theme {
-  --bg-color: #ffffff;
-  --text-color: #000000;
-  --accent-color: #ffd700;
+.dark-theme {
+  --bg-color: #000000;
+  --text-color: #ffffff;
+  --accent-color: #ffffff;
 }
 
 nav {
@@ -31,11 +32,11 @@ nav {
   align-items: center;
   padding: 1rem 2rem;
   background-color: var(--bg-color);
-  border-bottom: 2px solid var(--accent-color);
+  border-bottom: 1px solid var(--accent-color);
 }
 
 nav a {
-  color: var(--accent-color);
+  color: var(--text-color);
   margin-right: 1rem;
   text-decoration: none;
   font-weight: 700;
@@ -50,7 +51,7 @@ nav a::after {
   bottom: -4px;
   width: 0;
   height: 2px;
-  background: var(--accent-color);
+  background: var(--text-color);
   transition: width 0.3s;
 }
 
@@ -70,7 +71,8 @@ nav a:hover::after {
 
 #language-select, #theme-toggle {
   padding: 0.3rem 0.5rem;
-  background-color: var(--accent-color);
+  background-color: var(--text-color);
+  color: var(--bg-color);
   border: none;
   cursor: pointer;
   font-weight: 700;
@@ -78,22 +80,32 @@ nav a:hover::after {
 
 .logo {
   font-size: 1.5rem;
-  animation: glow 3s ease-in-out infinite alternate;
+  font-family: var(--heading-font);
 }
 
 .hero {
   text-align: center;
-  padding: 5rem 1rem;
-  background: linear-gradient(135deg, #000000 0%, #333333 100%);
-  background-size: 400% 400%;
-  animation: gradientMove 8s ease infinite;
+  padding: 4rem 1rem;
+  background-color: var(--bg-color);
+}
+
+.hero-image {
+  max-width: 100%;
+  height: auto;
+  margin-bottom: 2rem;
 }
 
  .product {
   border: 1px solid var(--accent-color);
   padding: 1rem;
-  margin: 1rem;
+  margin: 1rem 0;
   transition: transform 0.3s, box-shadow 0.3s;
+}
+
+.product-image {
+  width: 100%;
+  height: auto;
+  margin-bottom: 1rem;
 }
 
 .product:hover {
@@ -106,14 +118,15 @@ main {
 }
 
 h1, h2 {
-  color: var(--accent-color);
+  font-family: var(--heading-font);
+  color: var(--text-color);
 }
 
 .btn-primary {
   display: inline-block;
   margin-top: 1rem;
   padding: 0.75rem 1.5rem;
-  background: var(--accent-color);
+  background: var(--text-color);
   color: var(--bg-color);
   text-decoration: none;
   font-weight: 700;
@@ -137,16 +150,6 @@ h1, h2 {
   transform: translateY(0);
 }
 
-@keyframes gradientMove {
-  0% {background-position: 0% 50%;}
-  50% {background-position: 100% 50%;}
-  100% {background-position: 0% 50%;}
-}
-
-@keyframes glow {
-  from { text-shadow: 0 0 5px var(--accent-color); }
-  to { text-shadow: 0 0 20px var(--accent-color); }
-}
 
 @keyframes bodyFade {
   from { opacity: 0; }


### PR DESCRIPTION
## Summary
- Apply minimalist black-and-white styling and Playfair Display typography for a Dior-inspired look
- Add hero image and product catalog with irons, driver, and DragonEyes putter entries
- Expand translations and update theme toggle to use dark mode variant

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e08ec0c483229b1ff8cc566575e2