### PR TITLE
Fix carousel visibility and add sticky transparent navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
-  <nav class="animate">
+  <nav>
     <div class="logo">Kentack</div>
     <div>
       <a href="index.html" data-i18n="nav_home">Home</a>
@@ -27,7 +27,7 @@
   </nav>
 
   <main>
-    <section class="carousel animate">
+    <section class="carousel">
       <div class="image-wrapper">
         <div class="image-item"><img src="NEWIMAGES/378eab1265ecedb2b4fd10.jpg" alt="Showcase image 1"></div>
         <div class="image-item center-item">

--- a/script.js
+++ b/script.js
@@ -157,9 +157,26 @@ function initCarousel() {
   }, 5000);
 }
 
+function initNavScroll() {
+  const nav = document.querySelector('nav');
+  if (!nav) return;
+  const navHeight = nav.offsetHeight;
+  let lastScroll = window.pageYOffset;
+  window.addEventListener('scroll', () => {
+    const current = window.pageYOffset;
+    if (current > lastScroll) {
+      nav.style.top = `-${navHeight}px`;
+    } else {
+      nav.style.top = '0';
+    }
+    lastScroll = current;
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initLanguage();
   initTheme();
   initAnimations();
   initCarousel();
+  initNavScroll();
 });

--- a/style.css
+++ b/style.css
@@ -27,12 +27,23 @@ body {
 }
 
 nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
-  background-color: var(--bg-color);
+  background-color: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--accent-color);
+  transition: top 0.3s;
+  z-index: 1000;
+}
+
+.dark-theme nav {
+  background-color: rgba(0, 0, 0, 0.8);
 }
 
 nav a {
@@ -117,6 +128,7 @@ nav a:hover::after {
 
 main {
   padding: 2rem;
+  margin-top: 80px;
 }
 
 .product-grid {
@@ -185,8 +197,9 @@ h1, h2 {
 }
 
 .image-item {
-  flex: 1;
+  flex: 1 1 33.333%;
   position: relative;
+  overflow: hidden;
 }
 
 .image-item img {


### PR DESCRIPTION
## Summary
- Ensure hero carousel displays immediately and maintains consistent sizing
- Add semi-transparent fixed navbar that hides on scroll down and reappears on scroll up

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f0cba6f883228a007f14a11b42f2