### PR TITLE
Improve hero overlay and adaptive colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,8 +33,8 @@
         <div class="image-item center-item">
           <img src="NEWIMAGES/46776ce8a2162a48730711.jpg" alt="Showcase image 2">
           <div class="overlay">
-            <h2>The Theater of Fashion</h2>
-            <a href="#" class="overlay-link">Discover the Collection</a>
+            <h2>Kentack</h2>
+            <a href="products.html" class="overlay-link">Discover the Collection</a>
           </div>
         </div>
         <div class="image-item"><img src="NEWIMAGES/51ee9f72518cd9d2809d5.jpg" alt="Showcase image 3"></div>

--- a/script.js
+++ b/script.js
@@ -143,6 +143,13 @@ function initCarousel() {
     images.forEach((img, idx) => {
       img.src = imageSets[i][idx];
     });
+    if (images[1]) {
+      if (images[1].complete) {
+        updateOverlayColor();
+      } else {
+        images[1].addEventListener('load', updateOverlayColor, { once: true });
+      }
+    }
   }
 
   showSet(index);
@@ -155,6 +162,28 @@ function initCarousel() {
       images.forEach(img => img.classList.remove('fade'));
     }, 1000);
   }, 5000);
+}
+
+function updateOverlayColor() {
+  const img = document.querySelector('.center-item img');
+  if (!img) return;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  let r = 0, g = 0, b = 0;
+  const total = data.length / 4;
+  for (let i = 0; i < data.length; i += 4) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+  }
+  r /= total; g /= total; b /= total;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const color = luminance > 128 ? '#000000' : '#ffffff';
+  document.documentElement.style.setProperty('--overlay-color', color);
 }
 
 function initNavScroll() {

--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
   --accent-color: #ffd700;
   --font-family: 'Montserrat', sans-serif;
   --heading-font: 'Playfair Display', serif;
+  --overlay-color: #ffffff;
 }
 
 html {
@@ -219,14 +220,14 @@ h1, h2 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #ffffff;
+  color: var(--overlay-color);
   text-align: center;
 }
 
 .overlay-link {
-  color: #ffffff;
+  color: var(--overlay-color);
   text-decoration: none;
-  border-bottom: 1px solid #ffffff;
+  border-bottom: 1px solid var(--overlay-color);
   padding-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary
- Replace hero heading with "Kentack" and link the collection button to the catalog
- Add dynamic overlay color detection so hero text and link switch between white and black for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f408675083228696e1c1b5460bf3