### PR TITLE
Improve hero overlay and adaptive colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,16 @@
         <div class="image-item center-item">
           <img src="NEWIMAGES/46776ce8a2162a48730711.jpg" alt="Showcase image 2">
           <div class="overlay">
-            <h2>The Theater of Fashion</h2>
-            <a href="#" class="overlay-link">Discover the Collection</a>
+            <h2>Kentack</h2>
+            <a href="products.html" class="overlay-link" data-i18n="hero_cta">Discover the Collection</a>
           </div>
         </div>
         <div class="image-item"><img src="NEWIMAGES/51ee9f72518cd9d2809d5.jpg" alt="Showcase image 3"></div>
       </div>
+    </section>
+    <section class="story animate">
+      <h2 data-i18n="story_title">Message from Ken Karahawa</h2>
+      <p data-i18n="story_message">Do you know the name "Golf Honma"? From long ago, this has been the aspirational name of many golfers, a top-class "Made in Japan" golf club brand, widely supported not only in Japan but worldwide. Our KENTACK brand inherits the proud tradition and superior techniques that Golf Honma has preserved to this day. The current KENTACK Golf Company is built on the foundations of the Honma Golf Company. Honma Golf was originally founded by the Honma brothers, Yukihiro and Hiroo. After leaving the hands of these founders, it became a foreign-invested company. Founder Yukihiro Honma worried the brand identity he had worked so hard to build would be lost, so in 2007 he established KENTACK Golf to protect the Honma spirit and preserve its traditions and craftsmanship. During the golden era of golf clubs, Yukihiro Honma was a genius who created the highest-grade clubs of the time, naming his top-class clubs "HIRO HONMA". Like an artisan, he drew on 50 years of experience and craftsmanship, pursuing the harmony of performance and beauty, and re-launched the genuine Honma brand as KENTACK. After nearly ten years he no longer leads the company, but the traditions and techniques he left remain alive in KENTACK. Our clubs offer easier, more accurate, longer shots, with refined elegance and artistic design, made possible by meticulous Japanese craftsmanship. We promise to continue providing the highest-quality, top-class golf clubs, adding value for discerning customers, demonstrating that KENTACK deserves to preserve these features while never resting on the past and continuously advancing our technology.</p>
     </section>
   </main>
 

--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@ const translations = {
     language_label: 'Language',
     home_title: 'Kentack Luxury Golf Experience',
     home_desc: 'Discover high-end golf gear for champions.',
-    hero_cta: 'Shop Now',
+    hero_cta: 'Discover the Collection',
     story_title: 'Message from Ken Karahawa',
     story_message: `Do you know the name "Golf Honma"? From long ago, this has been the aspirational name of many golfers, a top-class "Made in Japan" golf club brand, widely supported not only in Japan but worldwide. Our KENTACK brand inherits the proud tradition and superior techniques that Golf Honma has preserved to this day. The current KENTACK Golf Company is built on the foundations of the Honma Golf Company. Honma Golf was originally founded by the Honma brothers, Yukihiro and Hiroo. After leaving the hands of these founders, it became a foreign-invested company. Founder Yukihiro Honma worried the brand identity he had worked so hard to build would be lost, so in 2007 he established KENTACK Golf to protect the Honma spirit and preserve its traditions and craftsmanship. During the golden era of golf clubs, Yukihiro Honma was a genius who created the highest-grade clubs of the time, naming his top-class clubs "HIRO HONMA". Like an artisan, he drew on 50 years of experience and craftsmanship, pursuing the harmony of performance and beauty, and re-launched the genuine Honma brand as KENTACK. After nearly ten years he no longer leads the company, but the traditions and techniques he left remain alive in KENTACK. Our clubs offer easier, more accurate, longer shots, with refined elegance and artistic design, made possible by meticulous Japanese craftsmanship. We promise to continue providing the highest-quality, top-class golf clubs, adding value for discerning customers, demonstrating that KENTACK deserves to preserve these features while never resting on the past and continuously advancing our technology.`,
     products_title: 'Our Products',
@@ -33,7 +33,7 @@ const translations = {
     language_label: 'Ngôn ngữ',
     home_title: 'Kentack - Trải nghiệm Golf Sang Trọng',
     home_desc: 'Khám phá thiết bị golf cao cấp dành cho nhà vô địch.',
-    hero_cta: 'Mua Ngay',
+    hero_cta: 'Khám phá bộ sưu tập',
     story_title: 'Thông điệp từ Ken Karahawa',
     story_message: `Quý vị có biết tên gọi “Golf Honma” không ? Từ xưa, đây là cái tên ao ước của rất nhiều người chơi Golf, là thương hiệu gậy Golf Made in Japan đẳng cấp hàng đầu, đã được sự ủng hộ lớn không chỉ trong nội địa nước Nhật mà ở cả thị trường toàn cầu. Thương hiệu KENTACK của công ty chúng tôi là thương hiệu được kế thừa truyền thống và kỹ thuật ưu việt có thể tự hào với cả thế giới mà công ty Golf Honma này đã gìn giữ được đến ngày nay. Công ty Golf KENTACK hiện tại được xây dựng trên nền tảng của Công ty Golf Honma. Công ty Golf Honma trước kia được sáng lập bởi hai anh em nhà Honma là Yukihiro Honma và Hiroo Honma, sau đó rời khỏi tay hai nhà sáng lập này, hiện nay trở thành công ty có vốn đầu tư nước ngoài. Do đó, nhà sáng lập Yukihiro Honma đã từng lo lắng công ty sẽ bị đánh mất dấu ấn thương hiệu do ông ra sức tạo dựng từ trước đến nay, nên đã thành lập công ty Golf KENTACK vào năm 2007, nhằm bảo vệ tinh thần Honma, gìn giữ phát huy những truyền thống và kỹ thuật trước đây. Trong toàn bộ thời hoàng kim của gậy Golf , Ông Yukihiro Honma là thiên tài khi tạo ra loại gậy Golf với thương hiệu cao cấp nhất thời bấy giờ, lấy chính tên mình làm thành gậy Golf đẳng cấp hàng đầu “HIRO HONMA”. Như là một nghệ nhân, ông đã vận dụng 50 năm kinh nghiệm và kỹ thuật làm gậy Golf, với phương châm là sự dung hòa giữa tính năng và cái đẹp, ông đã tái xuất phát với thương hiệu KENTACK, như là thương hiệu Honma chân chính được hồi sinh mới. Sau đó, trải qua gần 10 năm, Ông Yukihiro Honma đã không còn điều hành công ty, nhưng truyền thống và kỹ thuật do ông để lại đến nay vẫn được lưu giữ trong thương hiệu KENTACK. Với tính năng gậy Golf giúp đánh bóng “dễ đánh hơn”, “chính xác hơn”, “bay xa hơn”, có vẻ đẹp tinh tế, mẫu mã đẹp như một tác phẩm nghệ thuật. Điều này được thành hiện thực chính nhờ có bàn tay nghệ nhân Nhật chăm chút tỉ mĩ tạo nên. Chúng tôi xin hứa sẽ tiếp tục cung cấp gậy Golf với chất lượng cao, đẳng cấp nhất, tạo ra những giá trị cao thêm cho khách hàng yêu cầu cao, bằng việc thể hiện rằng KENTACK là truyền thống đáng được gìn giữ nguyên vẹn các tính năng như thế, nhưng không tự mãn với bề dày truyền thống ngày xưa mà không ngừng tích lũy nâng cao tính năng kỹ thuật mỗi ngày.`,
     products_title: 'Sản phẩm của chúng tôi',
@@ -59,7 +59,7 @@ const translations = {
     language_label: '言語',
     home_title: 'Kentack ラグジュアリーなゴルフ体験',
     home_desc: 'チャンピオンのための高級ゴルフ用品を見つけましょう。',
-    hero_cta: '今すぐ購入',
+    hero_cta: 'コレクションを見る',
     story_title: '唐川ケンからのメッセージ',
     story_message: `「ゴルフ本間」という名前をご存じでしょうか。昔から多くのゴルファーが憧れるこの名前は、日本国内だけでなく世界の市場でも大きな支持を得てきた、最高級のメイド・イン・ジャパンのゴルフクラブブランドです。私たちのKENTACKブランドは、この本間ゴルフが今日まで守り続けてきた伝統と優れた技術を受け継いでいます。現在のKENTACKゴルフは本間ゴルフを基盤として築かれました。本間ゴルフはもともと本間幸宏と本間洋夫の兄弟によって設立され、その後彼らの手を離れて外国資本の会社となりました。そのため創業者の本間幸宏は、自らが築き上げたブランドの証が失われることを危惧し、2007年にKENTACKゴルフを設立して本間の精神を守り、伝統と技術を継承することにしました。ゴルフクラブの黄金期において、本間幸宏は当時最高級のクラブブランド『HIRO HONMA』を生み出した天才でした。職人として彼は50年の経験と技術を活かし、性能と美の調和を理念として、真の本間ブランドを新たに蘇らせるKENTACKを再出発させました。その後約10年が経ち、本間幸宏は経営から退きましたが、彼の残した伝統と技術は今もKENTACKの中に生きています。私たちのクラブは『より打ちやすく』『より正確に』『より遠くへ』ボールを飛ばし、芸術作品のような洗練された美しさを備えています。これは日本の職人の細やかな手仕事によって実現しました。私たちは過去の伝統に満足することなく、日々技術を高めながら、KENTACKがこれらの特徴を守り続ける価値あるブランドであることを示し、最高品質・最高級のゴルフクラブをこだわりのあるお客様に提供し続けることをお約束します。`,
     products_title: '製品一覧',
@@ -143,6 +143,13 @@ function initCarousel() {
     images.forEach((img, idx) => {
       img.src = imageSets[i][idx];
     });
+    if (images[1]) {
+      if (images[1].complete) {
+        updateOverlayColor();
+      } else {
+        images[1].addEventListener('load', updateOverlayColor, { once: true });
+      }
+    }
   }
 
   showSet(index);
@@ -155,6 +162,28 @@ function initCarousel() {
       images.forEach(img => img.classList.remove('fade'));
     }, 1000);
   }, 5000);
+}
+
+function updateOverlayColor() {
+  const img = document.querySelector('.center-item img');
+  if (!img) return;
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+  let r = 0, g = 0, b = 0;
+  const total = data.length / 4;
+  for (let i = 0; i < data.length; i += 4) {
+    r += data[i];
+    g += data[i + 1];
+    b += data[i + 2];
+  }
+  r /= total; g /= total; b /= total;
+  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  const color = luminance > 128 ? '#000000' : '#ffffff';
+  document.documentElement.style.setProperty('--overlay-color', color);
 }
 
 function initNavScroll() {

--- a/style.css
+++ b/style.css
@@ -4,6 +4,7 @@
   --accent-color: #ffd700;
   --font-family: 'Montserrat', sans-serif;
   --heading-font: 'Playfair Display', serif;
+  --overlay-color: #ffffff;
 }
 
 html {
@@ -142,6 +143,11 @@ main {
   color: var(--accent-color);
 }
 
+.story {
+  max-width: 800px;
+  margin: 2rem auto;
+}
+
 .story p {
   white-space: pre-line;
   line-height: 1.6;
@@ -219,14 +225,14 @@ h1, h2 {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  color: #ffffff;
+  color: var(--overlay-color);
   text-align: center;
 }
 
 .overlay-link {
-  color: #ffffff;
+  color: var(--overlay-color);
   text-decoration: none;
-  border-bottom: 1px solid #ffffff;
+  border-bottom: 1px solid var(--overlay-color);
   padding-bottom: 4px;
 }
 


### PR DESCRIPTION
## Summary
- Replace hero heading with "Kentack" and link the collection button to the catalog
- Add dynamic overlay color detection so hero text and link switch between white and black for readability
- Render Ken Karahawa introduction below the carousel and localize the hero call to action

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f408675083228696e1c1b5460bf3