### PR TITLE
Center nav links and add icon controls

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -13,19 +13,21 @@
 <body>
   <nav class="animate">
     <div class="logo">Kentack</div>
-    <div>
+    <div class="nav-links">
       <a href="index.html" data-i18n="nav_home">Home</a>
       <a href="products.html" data-i18n="nav_products">Products</a>
       <a href="contact.html" data-i18n="nav_contact">Contact</a>
     </div>
     <div class="controls">
-      <label for="language-select" data-i18n="language_label">Language</label>
-      <select id="language-select">
-        <option value="en">English</option>
-        <option value="vi">Tiếng Việt</option>
-        <option value="ja">日本語</option>
-      </select>
-      <button id="theme-toggle" data-i18n="theme_toggle">Toggle Theme</button>
+      <div class="language-dropdown">
+        <button id="language-toggle" aria-label="Language">🌐</button>
+        <select id="language-select" class="hidden">
+          <option value="en">English</option>
+          <option value="vi">Tiếng Việt</option>
+          <option value="ja">日本語</option>
+        </select>
+      </div>
+      <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -13,19 +13,21 @@
 <body>
   <nav class="animate">
     <div class="logo">Kentack</div>
-    <div>
+    <div class="nav-links">
       <a href="index.html" data-i18n="nav_home">Home</a>
       <a href="products.html" data-i18n="nav_products">Products</a>
       <a href="contact.html" data-i18n="nav_contact">Contact</a>
     </div>
     <div class="controls">
-      <label for="language-select" data-i18n="language_label">Language</label>
-      <select id="language-select">
-        <option value="en">English</option>
-        <option value="vi">Tiếng Việt</option>
-        <option value="ja">日本語</option>
-      </select>
-      <button id="theme-toggle" data-i18n="theme_toggle">Toggle Theme</button>
+      <div class="language-dropdown">
+        <button id="language-toggle" aria-label="Language">🌐</button>
+        <select id="language-select" class="hidden">
+          <option value="en">English</option>
+          <option value="vi">Tiếng Việt</option>
+          <option value="ja">日本語</option>
+        </select>
+      </div>
+      <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
 
@@ -42,6 +44,10 @@
         </div>
         <div class="image-item"><img src="NEWIMAGES/51ee9f72518cd9d2809d5.jpg" alt="Showcase image 3" loading="lazy"></div>
       </div>
+    </section>
+    <section class="story animate">
+      <h2 data-i18n="story_title">Message from Ken Karahawa</h2>
+      <p data-i18n="story_message"></p>
     </section>
   </main>
 

--- a/products.html
+++ b/products.html
@@ -13,19 +13,21 @@
 <body>
   <nav class="animate">
     <div class="logo">Kentack</div>
-    <div>
+    <div class="nav-links">
       <a href="index.html" data-i18n="nav_home">Home</a>
       <a href="products.html" data-i18n="nav_products">Products</a>
       <a href="contact.html" data-i18n="nav_contact">Contact</a>
     </div>
     <div class="controls">
-      <label for="language-select" data-i18n="language_label">Language</label>
-      <select id="language-select">
-        <option value="en">English</option>
-        <option value="vi">Tiếng Việt</option>
-        <option value="ja">日本語</option>
-      </select>
-      <button id="theme-toggle" data-i18n="theme_toggle">Toggle Theme</button>
+      <div class="language-dropdown">
+        <button id="language-toggle" aria-label="Language">🌐</button>
+        <select id="language-select" class="hidden">
+          <option value="en">English</option>
+          <option value="vi">Tiếng Việt</option>
+          <option value="ja">日本語</option>
+        </select>
+      </div>
+      <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
 

--- a/script.js
+++ b/script.js
@@ -93,9 +93,18 @@ function setLanguage(lang) {
 function initLanguage() {
   const saved = localStorage.getItem('lang') || 'en';
   const select = document.getElementById('language-select');
+  const toggle = document.getElementById('language-toggle');
   if (select) {
     select.value = saved;
-    select.addEventListener('change', e => setLanguage(e.target.value));
+    select.addEventListener('change', e => {
+      setLanguage(e.target.value);
+      select.classList.add('hidden');
+    });
+  }
+  if (toggle && select) {
+    toggle.addEventListener('click', () => {
+      select.classList.toggle('hidden');
+    });
   }
   setLanguage(saved);
 }
@@ -107,9 +116,14 @@ function initTheme() {
   }
   const toggle = document.getElementById('theme-toggle');
   if (toggle) {
+    const updateIcon = () => {
+      toggle.textContent = document.body.classList.contains('dark-theme') ? '☀️' : '🌙';
+    };
+    updateIcon();
     toggle.addEventListener('click', () => {
       document.body.classList.toggle('dark-theme');
       localStorage.setItem('theme', document.body.classList.contains('dark-theme') ? 'dark' : 'light');
+      updateIcon();
     });
   }
 }

--- a/style.css
+++ b/style.css
@@ -82,13 +82,38 @@ nav a:hover::after {
   gap: 0.5rem;
 }
 
-#language-select, #theme-toggle {
+.nav-links {
+  flex: 1;
+  text-align: center;
+}
+
+.language-dropdown {
+  position: relative;
+}
+
+#language-select {
+  position: absolute;
+  top: 100%;
+  right: 0;
   padding: 0.3rem 0.5rem;
   background-color: var(--accent-color);
   color: #000000;
   border: none;
   cursor: pointer;
   font-weight: 700;
+}
+
+#language-toggle,
+#theme-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  color: var(--text-color);
+}
+
+.hidden {
+  display: none;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- Center navigation links and replace language/theme controls with globe and sun/moon icons
- Add collapsible language selector and responsive theme icon
- Display Ken's introduction on scroll using animated story section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6fdcad698832281e17e81edb2399f