### PR TITLE
Fix theme toggle visibility and set hero overlay text black

### DIFF
--- a/script.js
+++ b/script.js
@@ -179,25 +179,7 @@ function initCarousel() {
 }
 
 function updateOverlayColor() {
-  const img = document.querySelector('.center-item img');
-  if (!img) return;
-  const canvas = document.createElement('canvas');
-  const ctx = canvas.getContext('2d');
-  canvas.width = img.naturalWidth;
-  canvas.height = img.naturalHeight;
-  ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
-  const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
-  let r = 0, g = 0, b = 0;
-  const total = data.length / 4;
-  for (let i = 0; i < data.length; i += 4) {
-    r += data[i];
-    g += data[i + 1];
-    b += data[i + 2];
-  }
-  r /= total; g /= total; b /= total;
-  const luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
-  const color = luminance > 128 ? '#000000' : '#ffffff';
-  document.documentElement.style.setProperty('--overlay-color', color);
+  document.documentElement.style.setProperty('--overlay-color', '#000000');
 }
 
 function initNavScroll() {

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@
   --accent-color: #ffd700;
   --font-family: 'Montserrat', sans-serif;
   --heading-font: 'Playfair Display', serif;
-  --overlay-color: #ffffff;
+  --overlay-color: #000000;
 }
 
 html {
@@ -80,6 +80,7 @@ nav a:hover::after {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-shrink: 0;
 }
 
 .nav-links {


### PR DESCRIPTION
## Summary
- prevent header controls from shrinking so the theme toggle remains visible
- force hero overlay text color to black via CSS variable and script update

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7015bc73083229316342ef241fa30