### PR TITLE
Add Ken's image and fix theme toggle overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,10 @@
     </section>
     <section class="story animate">
       <h2 data-i18n="story_title">Message from Ken Karahawa</h2>
-      <p data-i18n="story_message"></p>
+      <div class="story-content">
+        <img src="https://kentack.co.jp/assets/images/ken-kawahara_r.jpg" alt="Ken Kawahara">
+        <p data-i18n="story_message"></p>
+      </div>
     </section>
   </main>
 

--- a/style.css
+++ b/style.css
@@ -36,6 +36,7 @@ nav {
   justify-content: space-between;
   align-items: center;
   padding: 1rem 2rem;
+  box-sizing: border-box;
   background-color: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(10px);
   border-bottom: 1px solid var(--accent-color);
@@ -172,6 +173,25 @@ main {
 .story p {
   white-space: pre-line;
   line-height: 1.6;
+}
+
+.story-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.story-content img {
+  max-width: 200px;
+  height: auto;
+  flex-shrink: 0;
+}
+
+@media (max-width: 600px) {
+  .story-content {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 h1, h2 {


### PR DESCRIPTION
## Summary
- Display Ken Kawahara's portrait alongside his introduction message
- Ensure navigation padding doesn't push the theme toggle off screen
- Style story section to place text and image side-by-side with responsive stacking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a704078e4c83228dd2754a1033d4da