### PR TITLE
Fix carousel images and resize Ken portrait

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
   <main>
     <section class="carousel">
       <div class="image-wrapper">
-        <div class="image-item"><img src="NEWIMAGES/378eab1265ecedb2b4fd10.jpg" alt="Showcase image 1" loading="lazy"></div>
+        <div class="image-item"><img src="NEWIMAGES/76da7245bcbb34e56daa12.jpg" alt="Showcase image 1" loading="lazy"></div>
         <div class="image-item center-item">
           <img src="NEWIMAGES/46776ce8a2162a48730711.jpg" alt="Showcase image 2" loading="lazy">
           <div class="overlay">
@@ -42,13 +42,13 @@
             <a href="products.html" class="overlay-link">Discover the Collection</a>
           </div>
         </div>
-        <div class="image-item"><img src="NEWIMAGES/51ee9f72518cd9d2809d5.jpg" alt="Showcase image 3" loading="lazy"></div>
+        <div class="image-item"><img src="NEWIMAGES/c976cce902178a49d3068.jpg" alt="Showcase image 3" loading="lazy"></div>
       </div>
     </section>
     <section class="story animate">
       <h2 data-i18n="story_title">Message from Ken Karahawa</h2>
       <div class="story-content">
-        <img src="https://kentack.co.jp/assets/images/ken-kawahara_r.jpg" alt="Ken Kawahara">
+        <img src="https://kentack.co.jp/assets/images/ken-kawahara_r.jpg" alt="Ken Kawahara" class="ken-portrait">
         <p data-i18n="story_message"></p>
       </div>
     </section>

--- a/script.js
+++ b/script.js
@@ -145,10 +145,8 @@ function initCarousel() {
   const images = Array.from(document.querySelectorAll('.image-item img'));
   if (!images.length) return;
   const imageSets = [
-    ['NEWIMAGES/378eab1265ecedb2b4fd10.jpg', 'NEWIMAGES/46776ce8a2162a48730711.jpg', 'NEWIMAGES/51ee9f72518cd9d2809d5.jpg'],
-    ['NEWIMAGES/572ccab0044e8c10d55f4.jpg', 'NEWIMAGES/6d11358dfb73732d2a627.jpg', 'NEWIMAGES/7402229eec60643e3d711.jpg'],
-    ['NEWIMAGES/76da7245bcbb34e56daa12.jpg', 'NEWIMAGES/c83f18a3d65d5e03074c2.jpg', 'NEWIMAGES/c976cce902178a49d3068.jpg'],
-    ['NEWIMAGES/c9791fe5d11b5945000a9.jpg', 'NEWIMAGES/ce2859b4974a1f14465b6.jpg', 'NEWIMAGES/f03bc0a40e5a8604df4b13.jpg']
+    ['NEWIMAGES/76da7245bcbb34e56daa12.jpg', 'NEWIMAGES/46776ce8a2162a48730711.jpg', 'NEWIMAGES/c976cce902178a49d3068.jpg'],
+    ['NEWIMAGES/c9791fe5d11b5945000a9.jpg', 'NEWIMAGES/f03bc0a40e5a8604df4b13.jpg', 'NEWIMAGES/76da7245bcbb34e56daa12.jpg']
   ];
 
   let index = 0;

--- a/style.css
+++ b/style.css
@@ -181,8 +181,8 @@ main {
   gap: 1rem;
 }
 
-.story-content img {
-  max-width: 200px;
+.story-content .ken-portrait {
+  width: 100px;
   height: auto;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Summary
- Replace missing carousel images with existing assets
- Shrink Ken Kawahara portrait and align beside message
- Ensure theme toggle remains available in navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a705e90a488322894f5b73df7b2445