### PR TITLE
Ensure Kentack logo remains black in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -199,6 +199,10 @@ h1, h2 {
   color: var(--text-color);
 }
 
+.overlay h2 {
+  color: var(--overlay-color);
+}
+
 .btn-primary {
   display: inline-block;
   margin-top: 1rem;


### PR DESCRIPTION
## Summary
- Maintain the central Kentack logo's black color when switching themes by giving the carousel overlay heading its own color rule.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a709b8251c83229eb9a321fb41b6f4