### PR TITLE
Add responsive device detection and layout adjustments

### DIFF
--- a/script.js
+++ b/script.js
@@ -274,6 +274,23 @@ function initNavScroll() {
   });
 }
 
+function initDeviceDetection() {
+  const body = document.body;
+  function updateDevice() {
+    const width = window.innerWidth;
+    body.classList.remove('device-phone', 'device-tablet', 'device-desktop');
+    if (width <= 600) {
+      body.classList.add('device-phone');
+    } else if (width <= 992) {
+      body.classList.add('device-tablet');
+    } else {
+      body.classList.add('device-desktop');
+    }
+  }
+  updateDevice();
+  window.addEventListener('resize', updateDevice);
+}
+
 const productData = [];
 
 function renderProducts(filter = {}) {
@@ -357,5 +374,6 @@ document.addEventListener('DOMContentLoaded', () => {
   initAnimations();
   initCarousel();
   initNavScroll();
+  initDeviceDetection();
   initProducts();
 });

--- a/style.css
+++ b/style.css
@@ -336,4 +336,47 @@ h1, h2 {
   padding-bottom: 4px;
 }
 
+/* Responsive styles for device-specific layouts */
+body.device-phone nav {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+body.device-phone .nav-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+body.device-phone .controls {
+  margin-top: 0.5rem;
+}
+
+body.device-phone .image-item img {
+  height: 40vh;
+}
+
+body.device-phone .product-grid.grid-4,
+body.device-phone .product-grid.grid-5 {
+  grid-template-columns: 1fr;
+}
+
+body.device-tablet .product-grid.grid-4 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+body.device-tablet .product-grid.grid-5 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+body.device-desktop .product-grid.grid-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+body.device-desktop .product-grid.grid-5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
 


### PR DESCRIPTION
## Summary
- detect device type on load and resize to assign phone, tablet, or desktop classes
- add responsive CSS using device classes to adjust navigation and product grid layouts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a73583793c832283410bc0e878589e