### PR TITLE
Fix carousel image replacement to slide properly

### DIFF
--- a/script.js
+++ b/script.js
@@ -187,15 +187,16 @@ function initCarousel() {
         }
         return;
       }
+      const prevImg = currentImg;
       const nextImg = document.createElement('img');
       nextImg.src = mobileImages[i];
       nextImg.classList.add('next');
       container.appendChild(nextImg);
       requestAnimationFrame(() => {
-        currentImg.classList.add('slide-out-left');
+        prevImg.classList.add('slide-out-left');
         nextImg.classList.add('slide-in-right');
       });
-      currentImg.addEventListener('transitionend', () => currentImg.remove(), { once: true });
+      prevImg.addEventListener('transitionend', () => prevImg.remove(), { once: true });
       nextImg.addEventListener('transitionend', () => {
         nextImg.classList.remove('next', 'slide-in-right');
         currentImg = nextImg;


### PR DESCRIPTION
## Summary
- prevent mobile carousel from stacking images by tracking previous image separately
- ensure new image slides in and old one is removed cleanly

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76c4e0b0083228ae2c4a9d070fefa