### PR TITLE
Improve carousel smoothness and overlay visibility

### DIFF
--- a/script.js
+++ b/script.js
@@ -226,6 +226,7 @@ function initCarousel() {
     items.forEach((item, idx) => {
       const currentImg = item.querySelector('img');
       if (!currentImg) return;
+      const overlay = item.querySelector('.overlay');
       if (instant) {
         currentImg.src = imageSets[i][idx];
         if (item === items[1]) {
@@ -240,7 +241,11 @@ function initCarousel() {
       const nextImg = document.createElement('img');
       nextImg.src = imageSets[i][idx];
       nextImg.classList.add('next');
-      item.appendChild(nextImg);
+      if (overlay) {
+        item.insertBefore(nextImg, overlay);
+      } else {
+        item.appendChild(nextImg);
+      }
       requestAnimationFrame(() => {
         currentImg.classList.add('slide-out-left');
         nextImg.classList.add('slide-in-right');

--- a/style.css
+++ b/style.css
@@ -322,7 +322,8 @@ h1, h2 {
   top: 0;
   left: 0;
   transform: translateX(0);
-  transition: transform 1s ease;
+  transition: transform 0.75s ease-in-out;
+  will-change: transform;
 }
 
 .image-item img.next {
@@ -344,6 +345,7 @@ h1, h2 {
   transform: translate(-50%, -50%);
   color: var(--overlay-color);
   text-align: center;
+  z-index: 1;
 }
 
 .overlay-link {


### PR DESCRIPTION
## Summary
- Smoothened carousel animation using ease-in-out transitions and GPU hints.
- Ensured overlay stays above carousel images with proper z-index.
- Preserved "Explore the Collection" overlay during image swaps by inserting new images before overlay.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76ea5f4c88322baa497515fd70568