### PR TITLE
Add mobile hamburger menu and full-screen carousel

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -11,6 +11,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
+  <button id="menu-toggle" aria-label="Menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
   <nav class="animate">
     <div class="logo">KENTACK</div>
     <div class="nav-links">

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
+  <button id="menu-toggle" aria-label="Menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
   <nav class="animate">
     <div class="logo">KENTACK</div>
     <div class="nav-links">

--- a/products.html
+++ b/products.html
@@ -11,6 +11,11 @@
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
 </head>
 <body>
+  <button id="menu-toggle" aria-label="Menu">
+    <span></span>
+    <span></span>
+    <span></span>
+  </button>
   <nav class="animate">
     <div class="logo">KENTACK</div>
     <div class="nav-links">

--- a/script.js
+++ b/script.js
@@ -317,6 +317,18 @@ function initNavScroll() {
   });
 }
 
+function initMobileMenu() {
+  const menuToggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('nav');
+  if (!menuToggle || !nav) return;
+  menuToggle.addEventListener('click', () => {
+    nav.classList.toggle('open');
+  });
+  nav.querySelectorAll('a').forEach(link => {
+    link.addEventListener('click', () => nav.classList.remove('open'));
+  });
+}
+
 function initDeviceDetection() {
   const body = document.body;
   function updateDevice() {
@@ -334,6 +346,8 @@ function initDeviceDetection() {
       body.classList.add(newDevice);
       currentDevice = newDevice;
       initCarousel();
+      const nav = document.querySelector('nav');
+      if (nav) nav.classList.remove('open');
     }
   }
   updateDevice();
@@ -423,6 +437,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initTheme();
   initAnimations();
   initDeviceDetection();
+  initMobileMenu();
   initNavScroll();
   initProducts();
 });

--- a/style.css
+++ b/style.css
@@ -53,6 +53,24 @@ nav.nav-hidden {
   background-color: rgba(0, 0, 0, 0.8);
 }
 
+#menu-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  z-index: 1001;
+}
+
+#menu-toggle span {
+  display: block;
+  width: 25px;
+  height: 3px;
+  background: var(--text-color);
+  margin: 4px 0;
+}
+
 nav a {
   color: var(--text-color);
   margin-right: 1rem;
@@ -356,17 +374,38 @@ h1, h2 {
 }
 
 /* Responsive styles for device-specific layouts */
+body.device-phone #menu-toggle {
+  display: flex;
+  position: fixed;
+  top: 1rem;
+  left: 1rem;
+}
+
 body.device-phone nav {
   flex-direction: column;
   align-items: flex-start;
+  width: 250px;
+  height: 100%;
+  padding: 2rem 1rem;
+  transform: translateX(-100%);
+  transition: transform 0.3s;
+}
+
+body.device-phone nav.open {
+  transform: translateX(0);
+}
+
+body.device-phone nav.nav-hidden {
+  transform: translateX(-100%);
 }
 
 body.device-phone .nav-links {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 0.5rem;
+  gap: 1rem;
   margin-top: 0.5rem;
+  width: 100%;
 }
 
 body.device-phone .controls {
@@ -379,7 +418,7 @@ body.device-phone .image-wrapper {
 
 body.device-phone .image-item {
   flex: none;
-  height: 40vh;
+  height: 100vh;
 }
 
 body.device-phone .image-item:not(.center-item) {


### PR DESCRIPTION
## Summary
- Add hamburger menu button and slide-out nav for mobile devices
- Expand mobile carousel images to take full screen height
- Close mobile nav when selecting links or resizing

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68a870563c388322b4d49ce18d53cc0f