### PR TITLE
Refine mobile navigation and carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -182,7 +182,6 @@ function initCarousel() {
       'images/carousel1.jpg',
       'images/carousel2.jpg',
       'images/carousel3.jpg',
-      'images/carousel4.jpg',
       'images/carousel5.jpg'
     ];
     let index = 0;

--- a/style.css
+++ b/style.css
@@ -379,19 +379,31 @@ body.device-phone #menu-toggle {
   position: fixed;
   top: 1rem;
   left: 1rem;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  padding: 0.5rem;
+  border-radius: 50%;
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
 body.device-phone nav {
+  display: none;
   flex-direction: column;
   align-items: flex-start;
   width: 250px;
   height: 100%;
   padding: 2rem 1rem;
+  position: fixed;
+  top: 0;
+  left: 0;
   transform: translateX(-100%);
   transition: transform 0.3s;
 }
 
 body.device-phone nav.open {
+  display: flex;
   transform: translateX(0);
 }
 
@@ -410,6 +422,11 @@ body.device-phone .nav-links {
 
 body.device-phone .controls {
   margin-top: 0.5rem;
+}
+
+body.device-phone .overlay-link {
+  white-space: nowrap;
+  font-size: 0.9rem;
 }
 
 body.device-phone .image-wrapper {


### PR DESCRIPTION
## Summary
- hide carousel4.jpg from mobile image rotation
- ensure "Explore the Collection" stays on one line on phones
- improve mobile navigation toggle with circular background and offscreen nav until opened

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8aa61e25c8322aa8c66c5f7d8cf82