### PR TITLE
Refine mobile navigation and image presentation

### DIFF
--- a/script.js
+++ b/script.js
@@ -303,7 +303,7 @@ function updateOverlayColor() {
 
 function initNavScroll() {
   const nav = document.querySelector('nav');
-  if (!nav) return;
+  if (!nav || document.body.classList.contains('device-phone')) return;
   let lastScroll = window.pageYOffset;
   window.addEventListener('scroll', () => {
     const current = window.pageYOffset;

--- a/style.css
+++ b/style.css
@@ -388,6 +388,11 @@ body.device-phone #menu-toggle {
   background-color: rgba(0, 0, 0, 0.2);
 }
 
+body.device-phone #menu-toggle span {
+  background: #ffffff;
+  width: 70%;
+}
+
 body.device-phone nav {
   display: none;
   flex-direction: column;
@@ -436,6 +441,10 @@ body.device-phone .image-wrapper {
 body.device-phone .image-item {
   flex: none;
   height: 100vh;
+}
+
+body.device-phone .image-item img {
+  object-fit: contain;
 }
 
 body.device-phone .image-item:not(.center-item) {


### PR DESCRIPTION
## Summary
- Display a clear hamburger icon inside the mobile menu button
- Prevent nav bar from showing on scroll in phone layout
- Ensure mobile carousel images fit without zooming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ae6a06988322a46282b3d8925d3e