### PR TITLE
Fix mobile menu icon and language selector

### DIFF
--- a/style.css
+++ b/style.css
@@ -386,14 +386,15 @@ h1, h2 {
     height: 40px;
     padding: 0.5rem;
     border-radius: 50%;
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: var(--bg-color);
+    border: 1px solid var(--text-color);
   }
 
   #menu-toggle span {
     width: 70%;
     height: 3px;
     margin: 4px auto;
-    background-color: #ffffff;
+    background-color: var(--text-color);
     border-radius: 2px;
   }
 
@@ -430,6 +431,12 @@ h1, h2 {
   }
 
   .controls {
+    margin-top: 0.5rem;
+  }
+
+  #language-select {
+    position: static;
+    width: 100%;
     margin-top: 0.5rem;
   }
 


### PR DESCRIPTION
## Summary
- Improve mobile hamburger contrast by using theme colors and border
- Keep language dropdown within the viewport on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa61358694832295d4bf97f0606450