### PR TITLE
feat: default to dark theme on first load

### DIFF
--- a/script.js
+++ b/script.js
@@ -134,7 +134,11 @@ function initLanguage() {
 }
 
 function initTheme() {
-  const saved = localStorage.getItem('theme');
+  let saved = localStorage.getItem('theme');
+  if (!saved) {
+    saved = 'dark';
+    localStorage.setItem('theme', 'dark');
+  }
   if (saved === 'dark') {
     document.body.classList.add('dark-theme');
   }


### PR DESCRIPTION
## Summary
- default to dark theme when no theme preference is stored

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac038a11408322a0c71bdbf4e47001