### PR TITLE
Add gap before KH888 section and reposition overlay text

### DIFF
--- a/style.css
+++ b/style.css
@@ -319,6 +319,7 @@ h1, h2 {
 .carousel {
   width: 100%;
   overflow: hidden;
+  margin-bottom: 8rem;
 }
 
 .image-wrapper {
@@ -389,11 +390,12 @@ h1, h2 {
 
 .intro-content {
   position: absolute;
-  top: 65%;
-  left: 50%;
+  top: 50%;
+  left: 70%;
   transform: translate(-50%, -50%);
   text-align: center;
   color: #000;
+  max-width: 200px;
 }
 
 .intro-content h2 {


### PR DESCRIPTION
## Summary
- Increase bottom margin on hero carousel to create space before KH888 intro.
- Reposition KH888 overlay text and limit its width so it sits inside the putter leg.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac15e162408322ada0f4b382ab2e2e