### PR TITLE
Center putter intro text and ensure black color

### DIFF
--- a/style.css
+++ b/style.css
@@ -390,9 +390,9 @@ h1, h2 {
 
 .intro-content {
   position: absolute;
-  top: 50%;
-  left: 70%;
-  transform: translate(-50%, -50%);
+  bottom: 10%;
+  left: 50%;
+  transform: translate(-50%, 0);
   text-align: center;
   color: #000;
   max-width: 200px;
@@ -402,10 +402,12 @@ h1, h2 {
   font-family: var(--heading-font);
   font-size: 2.5rem;
   margin: 0;
+  color: #000;
 }
 
 .intro-content p {
   margin: 0.5rem 0 1.5rem;
+  color: #000;
 }
 
 .intro-btn {


### PR DESCRIPTION
## Summary
- Centered putter intro text at the bottom of the image for better alignment.
- Forced black text styling for all elements within the putter intro section.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac179a6d5c83228d79d48bee773979