### PR TITLE
Shift putter intro text

### DIFF
--- a/style.css
+++ b/style.css
@@ -397,6 +397,11 @@ h1, h2 {
   color: #000;
 }
 
+#putter-intro .intro-content {
+  bottom: 2%;
+  left: 45%;
+}
+
 .intro-content h2 {
   font-family: var(--heading-font);
   font-size: 2.5rem;


### PR DESCRIPTION
## Summary
- Offset the putter introduction text to sit slightly left and lower beneath the club image for improved layout.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac2388c6dc832290d8d21a1a38e6f9