### PR TITLE
Make product modal scrollable with smaller images

### DIFF
--- a/products.html
+++ b/products.html
@@ -61,14 +61,19 @@
     </div>
     <div id="product-grid" class="product-grid grid-4"></div>
   </main>
-  <div id="product-modal" class="modal hidden">
-    <div class="modal-content">
-      <span class="close">&times;</span>
-      <img class="modal-image" src="" alt="">
-      <button class="prev" aria-label="Previous">&#10094;</button>
-      <button class="next" aria-label="Next">&#10095;</button>
+    <div id="product-modal" class="modal hidden">
+      <div class="modal-content">
+        <span class="close">&times;</span>
+        <img class="modal-image" src="" alt="">
+        <div class="modal-details">
+          <h2 class="modal-title"></h2>
+          <p class="modal-desc"></p>
+          <p class="modal-price price"></p>
+        </div>
+        <button class="prev" aria-label="Previous">&#10094;</button>
+        <button class="next" aria-label="Next">&#10095;</button>
+      </div>
     </div>
-  </div>
 
   <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -427,7 +427,7 @@ const productData = [
   }
 ];
 
-let modal, modalImg, modalPrev, modalNext, modalClose;
+let modal, modalContent, modalImg, modalPrev, modalNext, modalClose, modalTitle, modalDesc, modalPrice;
 let modalImages = [];
 let modalIndex = 0;
 let modalTimer;
@@ -435,6 +435,22 @@ let modalTimer;
 function openProductModal(product) {
   modalImages = product.images;
   modalIndex = 0;
+  const lang = document.documentElement.lang || 'en';
+  if (modalTitle) {
+    modalTitle.textContent = translations[lang][product.nameKey];
+    modalTitle.setAttribute('data-i18n', product.nameKey);
+  }
+  if (modalDesc) {
+    modalDesc.textContent = translations[lang][product.descKey];
+    modalDesc.setAttribute('data-i18n', product.descKey);
+  }
+  if (modalPrice) {
+    modalPrice.textContent = translations[lang][product.priceKey];
+    modalPrice.setAttribute('data-i18n', product.priceKey);
+  }
+  if (modalImg) {
+    modalImg.alt = translations[lang][product.nameKey];
+  }
   updateModalImage();
   modal.classList.remove('hidden');
   document.body.classList.add('modal-open');
@@ -451,6 +467,9 @@ function updateModalImage() {
   if (modalImg) {
     modalImg.src = modalImages[modalIndex];
   }
+  if (modalContent) {
+    modalContent.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 }
 
 function nextModalImage() {
@@ -466,10 +485,14 @@ function prevModalImage() {
 function initProductModal() {
   modal = document.getElementById('product-modal');
   if (!modal) return;
+  modalContent = modal.querySelector('.modal-content');
   modalImg = modal.querySelector('.modal-image');
   modalPrev = modal.querySelector('.prev');
   modalNext = modal.querySelector('.next');
   modalClose = modal.querySelector('.close');
+  modalTitle = modal.querySelector('.modal-title');
+  modalDesc = modal.querySelector('.modal-desc');
+  modalPrice = modal.querySelector('.modal-price');
   if (modalPrev) modalPrev.addEventListener('click', e => { e.stopPropagation(); prevModalImage(); });
   if (modalNext) modalNext.addEventListener('click', e => { e.stopPropagation(); nextModalImage(); });
   if (modalClose) modalClose.addEventListener('click', closeProductModal);

--- a/style.css
+++ b/style.css
@@ -167,9 +167,10 @@ nav a:hover::after {
 }
 
 .product-image {
-  width: 100%;
+  width: 80%;
   height: auto;
-  margin-bottom: 1rem;
+  display: block;
+  margin: 0 auto 1rem;
 }
 
 .product:hover {
@@ -566,13 +567,19 @@ body.device-desktop .product-grid.grid-5 {
   position: relative;
   max-width: 80%;
   max-height: 80%;
+  background: var(--bg-color);
+  color: var(--text-color);
+  padding: 1rem;
+  overflow-y: auto;
   animation: popIn 0.3s ease;
 }
 
 .modal-image {
   width: 100%;
-  height: auto;
+  max-height: 250px;
+  object-fit: contain;
   display: block;
+  margin: 0 auto;
 }
 
 .modal-content .prev,
@@ -602,6 +609,11 @@ body.device-desktop .product-grid.grid-5 {
   font-size: 2rem;
   color: #fff;
   cursor: pointer;
+}
+
+.modal-details {
+  margin-top: 1rem;
+  text-align: center;
 }
 
 @keyframes popIn {


### PR DESCRIPTION
## Summary
- Reduce product thumbnail size for a cleaner grid layout
- Display detailed product info in a scrollable modal with smaller images
- Add smooth scroll animation whenever the modal image changes

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec03406a4832288fa84a61e7c72ea