### PR TITLE
Highlight KH888 only in modal and update VN text

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,7 +70,7 @@ const translations = {
     contact_phone: 'Điện thoại: 0899033692',
     contact_location_title: 'Địa chỉ',
     contact_location: 'Phố Tân Mỹ, Phương Quan, Nam Từ Liêm, Hà Nội, Vietnam',
-    product_kh888_name: 'KH888',
+    product_kh888_name: 'Driver KH888',
     product_kh888_desc: 'Gậy driver hiệu suất cao.',
     product_kh888_price: 'Giá khởi điểm từ <em>29,000,000 VND</em>',
     product_kh888_details: 'Được chế tạo với crown carbon siêu nhẹ và mặt gậy phay chính xác, KH888 mang lại khoảng cách vượt trội và độ khoan dung ấn tượng. Hosel có thể điều chỉnh cho phép bạn tinh chỉnh loft và lie phù hợp với cú swing, trong khi shaft cao cấp mang lại cảm giác và khả năng kiểm soát tuyệt vời.'
@@ -550,10 +550,9 @@ function renderProducts(filter = {}) {
     const div = document.createElement('div');
     div.className = 'product animate';
     const name = translations[lang][p.nameKey];
-    const nameClass = p.id === 'kh888' ? 'kh888-highlight' : '';
     div.innerHTML = `
       <img src="${p.image}" alt="${name}" data-i18n-alt="${p.nameKey}" class="product-image" loading="lazy">
-      <h2 data-i18n="${p.nameKey}"${nameClass ? ` class="${nameClass}"` : ''}>${name}</h2>
+      <h2 data-i18n="${p.nameKey}">${name}</h2>
       <p data-i18n="${p.descKey}">${translations[lang][p.descKey]}</p>
       <p class="price" data-i18n="${p.priceKey}">${translations[lang][p.priceKey]}</p>
     `;


### PR DESCRIPTION
## Summary
- Update Vietnamese translation to display **Driver KH888**
- Remove KH888 highlight class from product grid so only modal title uses yellow accent

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aec8d58f908322919b1ba10845b7f5