### PR TITLE
feat: lighten modal price color

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
   --bg-color: #ffffff;
   --text-color: #000000;
   --accent-color: #ffd700;
+  --price-color: #fff4b2;
   --font-family: 'Montserrat', sans-serif;
   --heading-font: 'Playfair Display', serif;
   --overlay-color: #000000;
@@ -602,8 +603,13 @@ body.device-desktop .product-grid.grid-5 {
   padding: 0.5rem 0;
 }
 
+.modal-title {
+  color: var(--accent-color);
+}
+
 .modal-price {
   font-weight: bold;
+  color: var(--price-color);
 }
 
 .kh888-highlight {


### PR DESCRIPTION
## Summary
- add dedicated price color variable and style
- display product name in accent color and price in lighter yellow in product modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2478e6c8322a889e050d8f2a195