### PR TITLE
Adjust KH888 product image alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,6 +174,11 @@ nav a:hover::after {
   margin-bottom: 1rem;
 }
 
+/* Shift KH888 driver image slightly left for better framing */
+.product-image[src="DRIVERS/KH888/KH888.jpg"] {
+  object-position: 40% center;
+}
+
 .product:hover {
   transform: translateY(-5px);
   box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);


### PR DESCRIPTION
## Summary
- Shift KH888 driver image slightly left on products page for improved framing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eb8eae608322a0b9d2ea86f0a73b