### PR TITLE
Shift KH888 image left on products page

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,9 +174,9 @@ nav a:hover::after {
   margin-bottom: 1rem;
 }
 
-/* Shift KH888 driver image slightly left for better framing */
+/* Shift KH888 driver image slightly further left for better framing */
 .product-image[src="DRIVERS/KH888/KH888.jpg"] {
-  object-position: 55% center;
+  object-position: 60% center;
 }
 
 .product:hover {


### PR DESCRIPTION
## Summary
- shift KH888 driver thumbnail slightly left for better framing

## Testing
- `npx prettier --check style.css` *(fails: Code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f6169f608322bc0f678e5f470f03