### PR TITLE
Adjust KH888 putter image alignment on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -401,6 +401,12 @@ h1, h2 {
   object-position: 55% center;
 }
 
+@media (max-width: 600px) {
+  #putter-intro img {
+    object-position: 65% center;
+  }
+}
+
 .intro-content {
   position: absolute;
   bottom: 5%;


### PR DESCRIPTION
## Summary
- Refine KH888 putter intro image positioning for smaller screens so it sits slightly right of center.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b48365ab788322ae4bcac84c86e105