### PR TITLE
Remove missing KH555 image from carousel

### DIFF
--- a/script.js
+++ b/script.js
@@ -496,8 +496,7 @@ const productData = [
       'KH555/9182c9a214b86d5914344b07696bfe3e.jpg',
       'KH555/2781a0ba27f8d0c53a3f435136f0b1e1.jpg',
       'KH555/30f2ed2ad346e02591f747cee3e8a232.jpg',
-      'KH555/7b7e2b56cc90f6bbbbb50675905656b5.jpg',
-      'KH555/s.jpg'
+      'KH555/7b7e2b56cc90f6bbbbb50675905656b5.jpg'
     ],
     category: 'clubs',
     type: 'drivers'


### PR DESCRIPTION
## Summary
- fix KH555 product carousel by removing reference to nonexistent image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b44dbc388322ac2aa5e7e8a95adf