### PR TITLE
Replace contact page with animated Vietnam map

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,46 +3,37 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Get in touch with Kentack for premium golf gear inquiries.">
-  <title>Kentack - Contact</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="style.css">
-  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+  <title>Contact - Vietnam Map</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, #map {
+      height: 100%;
+      margin: 0;
+    }
+    .leaflet-tile {
+      filter: grayscale(100%);
+    }
+  </style>
 </head>
 <body>
-  <button id="menu-toggle" aria-label="Menu">
-    <span></span>
-    <span></span>
-    <span></span>
-  </button>
-  <nav class="animate">
-    <div class="logo">KENTACK</div>
-    <div class="nav-links">
-      <a href="index.html" data-i18n="nav_home">Home</a>
-      <a href="products.html" data-i18n="nav_products">Products</a>
-      <a href="contact.html" data-i18n="nav_contact">Contact</a>
-    </div>
-    <div class="controls">
-      <div class="language-dropdown">
-        <button id="language-toggle" aria-label="Language">🌐</button>
-        <select id="language-select" class="hidden">
-          <option value="en">English</option>
-          <option value="vi">Tiếng Việt</option>
-          <option value="ja">日本語</option>
-        </select>
-      </div>
-      <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
-    </div>
-  </nav>
+  <div id="map"></div>
 
-  <main>
-    <h1 class="animate" data-i18n="contact_title">Contact Us</h1>
-    <p class="animate" data-i18n="contact_phone">Phone: 0899033692</p>
-    <h2 class="animate" data-i18n="contact_location_title">Location</h2>
-    <p class="animate" data-i18n="contact_location">Phố Tân Mỹ, Phương Quan, Nam Từ Liêm, Hà Nội, Vietnam</p>
-  </main>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script>
+    const map = L.map('map');
+    const vietnamBounds = [[8.179, 102.144], [23.392, 109.464]];
 
-  <script src="script.js"></script>
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    map.fitBounds(vietnamBounds);
+
+    const hanoi = [21.0278, 105.8342];
+    setTimeout(() => {
+      map.setView(hanoi, 12, { animate: true, duration: 2 });
+    }, 1000);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Rebuild contact page to display a grayscale Leaflet map of Vietnam
- Animate map to zoom into Hanoi after load

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e0e95e0083228a7620ac71aaa3f4