### PR TITLE
Add CartoDB dark basemap clipped to Vietnam

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -74,6 +74,32 @@
             map.setMaxBounds(bounds);
             map.setMinZoom(map.getZoom());
 
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+              attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>',
+              subdomains: 'abcd',
+              maxZoom: 19
+            }).addTo(map);
+
+            const worldCoords = [
+              [90, -180],
+              [90, 180],
+              [-90, 180],
+              [-90, -180]
+            ];
+
+            const vietnamCoords = [];
+            vietnamLayer.eachLayer(layer => {
+              const latlngs = layer.getLatLngs()[0];
+              vietnamCoords.push(latlngs.map(ll => [ll.lat, ll.lng]));
+            });
+
+            L.polygon([worldCoords, ...vietnamCoords], {
+              stroke: false,
+              fillColor: '#000',
+              fillOpacity: 1,
+              interactive: false
+            }).addTo(map);
+
             const points = [
               { coords: [21.025714568715166, 105.7585740417602], label: 'San phuong dong' },
               { coords: [21.04441803000998, 105.88411139998547], label: 'San dao sen' }


### PR DESCRIPTION
## Summary
- Display CartoDB's dark basemap on the contact page and restrict the map view to Vietnam only
- Mask surrounding countries to prevent tile display outside Vietnam's borders

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb2ea8948322bc73627f5d053563