### PR TITLE
Ensure contact page map zooms to golf course markers

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -110,8 +110,17 @@
                 color: '#ff0000',
                 fillColor: '#ff0000',
                 fillOpacity: 0.8
-              }).addTo(map).bindPopup(p.label).openPopup();
+              })
+                .addTo(map)
+                .bindPopup(p.label, {
+                  autoClose: false,
+                  closeOnClick: false
+                })
+                .openPopup();
             });
+
+            const markerBounds = L.latLngBounds(points.map(p => p.coords));
+            map.flyToBounds(markerBounds, { padding: [50, 50] });
           });
       });
     </script>


### PR DESCRIPTION
## Summary
- Zoom the contact page's Leaflet map to fit the Hanoi golf course markers
- Keep both marker popups open for easy location viewing

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9efd085f883229b52cbc4cafd11d5