### PR TITLE
Fix map zoom to highlight selected coordinates

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -71,7 +71,6 @@
 
             const bounds = vietnamLayer.getBounds();
             map.fitBounds(bounds);
-            map.setMaxBounds(bounds);
             map.setMinZoom(map.getZoom());
 
             L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
@@ -121,6 +120,7 @@
 
             const markerBounds = L.latLngBounds(points.map(p => p.coords));
             map.flyToBounds(markerBounds, { padding: [50, 50] });
+            map.setMaxBounds(bounds);
           });
       });
     </script>


### PR DESCRIPTION
## Summary
- Reorder map initialization so bounding constraints are applied after zooming to marker bounds.
- Preserve country view limit while allowing automatic focus on specified markers.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f33fad6c8322bf45a5e7c9295a6a