### PR TITLE
Fix contact map zoom for Hanoi markers

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -70,8 +70,6 @@
             }).addTo(map);
 
             const bounds = vietnamLayer.getBounds();
-            map.fitBounds(bounds);
-            map.setMinZoom(map.getZoom());
 
             L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
               attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>',
@@ -150,9 +148,7 @@
             });
 
             const markerBounds = L.latLngBounds(points.map(p => p.coords));
-            map.whenReady(() => {
-              map.fitBounds(markerBounds, { padding: [50, 50] });
-            });
+            map.fitBounds(markerBounds, { padding: [50, 50] });
             map.setMaxBounds(bounds);
           });
       });


### PR DESCRIPTION
## Summary
- Remove initial country fit and min zoom to allow marker focus
- Automatically fit map to Hanoi golf markers and restrict panning to Vietnam

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68badcb7ebe88322ba8291bb4ab76b30