### PR TITLE
Ensure content visible without JavaScript

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Contact - Vietnam Map</title>
+  <script>document.documentElement.classList.add('js');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="style.css">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="KENTACK offers luxury golf equipment and accessories.">
   <title>KENTACK</title>
+  <script>document.documentElement.classList.add('js');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="style.css">

--- a/products.html
+++ b/products.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Kentack's collection of premium golf clubs and accessories.">
   <title>Kentack - Products</title>
+  <script>document.documentElement.classList.add('js');</script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="style.css">

--- a/style.css
+++ b/style.css
@@ -17,8 +17,6 @@ body {
   font-family: var(--font-family);
   background-color: var(--bg-color);
   color: var(--text-color);
-  opacity: 0;
-  animation: bodyFade 1s ease-in forwards;
   transition: background-color 0.5s, color 0.5s;
 }
 
@@ -308,20 +306,17 @@ h1, h2 {
 }
 
 .animate {
-  opacity: 0;
-  transform: translateY(20px);
   transition: opacity 0.6s ease-out, transform 0.6s ease-out;
 }
 
-.animate.show {
-  opacity: 1;
-  transform: translateY(0);
+.js .animate {
+  opacity: 0;
+  transform: translateY(20px);
 }
 
-
-@keyframes bodyFade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+.js .animate.show {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Carousel Styles */


### PR DESCRIPTION
## Summary
- Stop hiding site content when JavaScript fails by removing body-level opacity/animation and gating animations behind a `.js` class.
- Add early inline script on every page to flag JS-enabled browsers before styles load, preventing blank pages.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68becca23c0c8322ba2d5b2f61670771