### PR TITLE
Fix product specs template string

### DIFF
--- a/script.js
+++ b/script.js
@@ -79,7 +79,7 @@ const translations = {
     product_white_oyster_name: 'White Pearl / 24K Gold Hollow Forged Irons',
     product_white_oyster_desc: 'Precision. Elegance. Unrivaled Performance.',
     product_white_oyster_price: 'Price upon request.',
-    product_white_oyster_details: `Elevate your game with the White Pearl / 24K Gold Hollow-Forged Irons — a stunning blend of art and performance that redefines what it means to swing in style. From their exquisite gold accents and luminous White Pearl finish to the silky NS950 Gold shafts, every detail communicates refinement. These irons deliver impressive feel, forgiving launch, and an unmistakable presence at address: power with poise, forged for those who demand the best in both aesthetics and functionality.',
+    product_white_oyster_details: `Elevate your game with the White Pearl / 24K Gold Hollow-Forged Irons — a stunning blend of art and performance that redefines what it means to swing in style. From their exquisite gold accents and luminous White Pearl finish to the silky NS950 Gold shafts, every detail communicates refinement. These irons deliver impressive feel, forgiving launch, and an unmistakable presence at address: power with poise, forged for those who demand the best in both aesthetics and functionality.`,
     product_white_oyster_specs: `
 <table class="spec-table">
   <tr><th colspan="2">WHITE PEARL / 24K GOLD HOLLOW FORGED IRONS</th></tr>


### PR DESCRIPTION
## Summary
- fix the English translation template literal for the White Pearl irons so the script parses correctly

## Testing
- node --check script.js

------
https://chatgpt.com/codex/tasks/task_e_68c9815d7598832282904ee6a590a73b