### PR TITLE
Adjust mobile hero positioning and menu toggle styling

### DIFF
--- a/script.js
+++ b/script.js
@@ -446,11 +446,18 @@ function initMobileMenu() {
   const menuToggle = document.getElementById('menu-toggle');
   const nav = document.querySelector('nav');
   if (!menuToggle || !nav) return;
+  menuToggle.setAttribute('aria-expanded', 'false');
   menuToggle.addEventListener('click', () => {
-    nav.classList.toggle('open');
+    const isOpen = nav.classList.toggle('open');
+    menuToggle.classList.toggle('open', isOpen);
+    menuToggle.setAttribute('aria-expanded', String(isOpen));
   });
   nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => nav.classList.remove('open'));
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      menuToggle.classList.remove('open');
+      menuToggle.setAttribute('aria-expanded', 'false');
+    });
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -398,7 +398,7 @@ h1, h2 {
 
 @media (max-width: 600px) {
   #putter-intro img {
-    object-position: 65% center;
+    object-position: 78% center;
   }
 }
 
@@ -453,19 +453,20 @@ h1, h2 {
     left: 1rem;
     align-items: center;
     justify-content: center;
-    width: 40px;
-    height: 40px;
-    padding: 0.5rem;
+    width: 44px;
+    height: 44px;
+    padding: 0;
     border-radius: 50%;
-    background-color: var(--bg-color);
-    border: 1px solid var(--text-color);
+    background-color: var(--text-color);
+    border: none;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }
 
   #menu-toggle span {
-    width: 70%;
+    width: 60%;
     height: 3px;
     margin: 4px auto;
-    background-color: var(--text-color);
+    background-color: var(--bg-color);
     border-radius: 2px;
   }
 


### PR DESCRIPTION
## Summary
- shift the KH888 hero image crop further right on small screens to better frame the product
- restyle the mobile menu toggle as a high-contrast circular hamburger button and update its accessibility state handling

## Testing
- Manual verification on local build (mobile viewport)


------
https://chatgpt.com/codex/tasks/task_e_68d94c89d30483308a6293689d0e7b34