### PR TITLE
Adjust mobile navigation and KH888 mobile presentation

### DIFF
--- a/style.css
+++ b/style.css
@@ -398,7 +398,7 @@ h1, h2 {
 
 @media (max-width: 600px) {
   #putter-intro img {
-    object-position: 78% center;
+    object-position: 45% center;
   }
 }
 
@@ -457,7 +457,7 @@ h1, h2 {
     height: 44px;
     padding: 0;
     border-radius: 50%;
-    background-color: var(--text-color);
+    background-color: #000000;
     border: none;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }
@@ -466,7 +466,7 @@ h1, h2 {
     width: 60%;
     height: 3px;
     margin: 4px auto;
-    background-color: var(--bg-color);
+    background-color: #ffffff;
     border-radius: 2px;
   }
 


### PR DESCRIPTION
## Summary
- invert the mobile hamburger toggle to a black button with white bars for better contrast
- shift the KH888 putter hero image left on small screens to keep the head centered

## Testing
- python3 -m http.server 8000 (manual visual check)


------
https://chatgpt.com/codex/tasks/task_e_68d9fdf405088330bf5fccfd3c86deb3