### PR TITLE
Improve mobile navigation layering

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -47,6 +47,7 @@
       <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
+  <div id="nav-overlay"></div>
 
   <main>
     <div id="map"></div>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
       <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
+  <div id="nav-overlay"></div>
 
   <main>
     <section class="carousel">

--- a/products.html
+++ b/products.html
@@ -36,6 +36,7 @@
       <button id="theme-toggle" aria-label="Toggle Theme">🌙</button>
     </div>
   </nav>
+  <div id="nav-overlay"></div>
 
   <main>
     <h1 class="animate" data-i18n="products_title">Our Products</h1>

--- a/script.js
+++ b/script.js
@@ -445,20 +445,28 @@ function initIntroScroll() {
 function initMobileMenu() {
   const menuToggle = document.getElementById('menu-toggle');
   const nav = document.querySelector('nav');
+  const overlay = document.getElementById('nav-overlay');
   if (!menuToggle || !nav) return;
-  menuToggle.setAttribute('aria-expanded', 'false');
-  menuToggle.addEventListener('click', () => {
-    const isOpen = nav.classList.toggle('open');
+
+  const setMenuState = isOpen => {
+    nav.classList.toggle('open', isOpen);
     menuToggle.classList.toggle('open', isOpen);
     menuToggle.setAttribute('aria-expanded', String(isOpen));
+    if (overlay) {
+      overlay.classList.toggle('active', isOpen);
+    }
+  };
+
+  setMenuState(false);
+
+  menuToggle.addEventListener('click', () => {
+    const shouldOpen = !nav.classList.contains('open');
+    setMenuState(shouldOpen);
   });
-  nav.querySelectorAll('a').forEach(link => {
-    link.addEventListener('click', () => {
-      nav.classList.remove('open');
-      menuToggle.classList.remove('open');
-      menuToggle.setAttribute('aria-expanded', 'false');
-    });
-  });
+
+  if (overlay) {
+    overlay.addEventListener('click', () => setMenuState(false));
+  }
 }
 
 function initDeviceDetection() {
@@ -480,6 +488,13 @@ function initDeviceDetection() {
       initCarousel();
       const nav = document.querySelector('nav');
       if (nav) nav.classList.remove('open');
+      const menuToggle = document.getElementById('menu-toggle');
+      if (menuToggle) {
+        menuToggle.classList.remove('open');
+        menuToggle.setAttribute('aria-expanded', 'false');
+      }
+      const overlay = document.getElementById('nav-overlay');
+      if (overlay) overlay.classList.remove('active');
     }
   }
   updateDevice();

--- a/style.css
+++ b/style.css
@@ -41,7 +41,7 @@ nav {
   border-bottom: 1px solid var(--accent-color);
   transform: translateY(0);
   transition: transform 0.3s;
-  z-index: 1000;
+  z-index: 1200;
 }
 
 nav.nav-hidden {
@@ -59,7 +59,27 @@ nav.nav-hidden {
   background: none;
   border: none;
   cursor: pointer;
-  z-index: 1001;
+  z-index: 1300;
+}
+
+#nav-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.4);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s;
+  pointer-events: none;
+  z-index: 1100;
+}
+
+#nav-overlay.active {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 #menu-toggle span {
@@ -457,7 +477,7 @@ h1, h2 {
     height: 44px;
     padding: 0;
     border-radius: 50%;
-    background-color: #000000;
+    background-color: rgba(0, 0, 0, 0.65);
     border: none;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }


### PR DESCRIPTION
## Summary
- add a full-screen overlay so the mobile navigation sits above the page and closes via outside taps
- update the hamburger background to a translucent black for better visibility

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db9c7de2e88330a3ba851fb87d75bc