### PR TITLE
Adjust mobile-specific navigation and imagery behavior

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -63,7 +63,7 @@
         ];
 
         const markerBounds = L.latLngBounds(points.map(p => p.coords));
-        const map = L.map('map', { maxBoundsViscosity: 1.0 }).fitBounds(markerBounds);
+        const map = L.map('map', { maxBoundsViscosity: 1.0, zoomControl: false }).fitBounds(markerBounds);
 
         L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
           attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors &copy; <a href="https://carto.com/attribution">CARTO</a>',

--- a/index.html
+++ b/index.html
@@ -54,7 +54,10 @@
     </section>
 
     <section class="product-intro animate" id="putter-intro">
-      <img src="PUTTER/KH888/595c21aabfe25b8b6486270de8992a81.jpg" alt="PUTTER KH888" loading="lazy">
+      <picture>
+        <source media="(max-width: 600px)" srcset="PUTTER/KH888/29aa952c251fd638f0f56f17ddee6046.jpg">
+        <img src="PUTTER/KH888/595c21aabfe25b8b6486270de8992a81.jpg" alt="PUTTER KH888" loading="lazy">
+      </picture>
       <div class="intro-content">
         <h2>PUTTER<br>KH888</h2>
           <p data-i18n="crafted_limited_timeless">Crafted. Limited. Timeless.</p>

--- a/style.css
+++ b/style.css
@@ -88,6 +88,7 @@ nav.nav-hidden {
   height: 3px;
   background: var(--text-color);
   margin: 4px 0;
+  transition: opacity 0.3s ease;
 }
 
 nav a {
@@ -488,6 +489,10 @@ h1, h2 {
     margin: 4px auto;
     background-color: #ffffff;
     border-radius: 2px;
+  }
+
+  #menu-toggle.open span {
+    opacity: 0;
   }
 
   nav {


### PR DESCRIPTION
## Summary
- hide the hamburger icon lines when the mobile navigation is open
- swap the KH888 putter hero image on mobile for the requested asset
- remove the zoom control buttons from the Leaflet map on the contact page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc97c60f3483308ac2dd2e1ea439b6