### PR TITLE
Tweak mobile hero alignment and menu toggle state

### DIFF
--- a/style.css
+++ b/style.css
@@ -91,6 +91,10 @@ nav.nav-hidden {
   transition: opacity 0.3s ease;
 }
 
+#menu-toggle.open span {
+  opacity: 0;
+}
+
 nav a {
   color: var(--text-color);
   margin-right: 1rem;
@@ -420,6 +424,10 @@ h1, h2 {
 @media (max-width: 600px) {
   #putter-intro img {
     object-position: 42% center;
+  }
+
+  #putter-intro .intro-content {
+    bottom: 32%;
   }
 }
 


### PR DESCRIPTION
## Summary
- raise the KH888 hero text on mobile to improve its placement within the hero image
- ensure the hamburger icon lines disappear when the mobile navigation is open for visual clarity

## Testing
- Manual verification in a mobile-width browser


------
https://chatgpt.com/codex/tasks/task_e_68dcc58a2d148330a03cb9fc65976b87