### PR TITLE
Adjust mobile tagline color on home page

### DIFF
--- a/style.css
+++ b/style.css
@@ -432,6 +432,10 @@ h1, h2 {
   #putter-intro .intro-content {
     bottom: 75%;
   }
+
+  #putter-intro .intro-content p {
+    color: #ffffff;
+  }
 }
 
 .intro-content {


### PR DESCRIPTION
## Summary
- update the mobile-specific styles for the PUTTER KH888 intro section
- ensure the tagline text renders in white on small screens for all languages

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd390891ac8330b2006eaf9f9578f1