### PR TITLE
Adjust mobile positioning for putter intro text

### DIFF
--- a/style.css
+++ b/style.css
@@ -430,7 +430,7 @@ h1, h2 {
   }
 
   #putter-intro .intro-content {
-    bottom: 99%;
+    bottom: 112%;
   }
 
   #putter-intro .intro-content p {


### PR DESCRIPTION
## Summary
- raise the mobile layout bottom offset for the putter intro text to place it higher on screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7243ec50833087ea2ee97ae97c9e