### PR TITLE
Adjust putter intro text positioning on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -429,10 +429,6 @@ h1, h2 {
     object-position: 42% center;
   }
 
-  #putter-intro .intro-content {
-    bottom: 500%;
-  }
-
   #putter-intro .intro-content p {
     color: #000000;
   }
@@ -450,6 +446,13 @@ h1, h2 {
 #putter-intro .intro-content {
   bottom: 20%;
   left: 49%;
+}
+
+@media (max-width: 600px) {
+  #putter-intro .intro-content {
+    top: 18%;
+    bottom: auto;
+  }
 }
 
 .intro-content h2 {


### PR DESCRIPTION
## Summary
- adjust the cascading order so the KH888 intro text can be repositioned independently on mobile
- raise the intro copy toward the top of the image on narrow viewports while keeping desktop placement intact

## Testing
- Manually viewed in a mobile-width browser window

------
https://chatgpt.com/codex/tasks/task_e_68dd7635037c833096a0c78dd75c2213